### PR TITLE
Notifications metabox: Check 'post' query var is set before populating

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -642,8 +642,8 @@ if ( ! class_exists('PP_Module')) {
              * @param array $users
              * @param int   $post_id
              */
-            $users = apply_filters('publishpress_notification_users_meta_box', get_users($args),
-                (int)$_GET['post']);
+            $post_id = isset($_GET['post']) ? (int)$_GET['post'] : null;
+            $users = apply_filters('publishpress_notification_users_meta_box', get_users($args), $post_id);
 
             if ( ! is_array($selected)) {
                 $selected = [];
@@ -665,8 +665,8 @@ if ( ! class_exists('PP_Module')) {
              * @param array $roles
              * @param int   $post_id
              */
-            $roles = apply_filters('publishpress_notification_roles_meta_box', get_editable_roles(),
-                (int)$_GET['post']);
+            $post_id = isset($_GET['post']) ? (int)$_GET['post'] : null;
+            $roles = apply_filters('publishpress_notification_roles_meta_box', get_editable_roles(), $post_id);
             ?>
 
             <?php if ( ! empty($users) || ! empty($roles) || ! empty($emails)) : ?>

--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -665,7 +665,6 @@ if ( ! class_exists('PP_Module')) {
              * @param array $roles
              * @param int   $post_id
              */
-            $post_id = isset($_GET['post']) ? (int)$_GET['post'] : null;
             $roles = apply_filters('publishpress_notification_roles_meta_box', get_editable_roles(), $post_id);
             ?>
 


### PR DESCRIPTION
Currently, with wp_debug enabled, an 'Undefined index' notice is shown when creating a new post since it's checking for a query variable that doesn't exist yet