### PR TITLE
Exclude taxonomies on slug when retrieving terms

### DIFF
--- a/libraries/Notifications/Workflow/Step/Event_Content/Filter/Term.php
+++ b/libraries/Notifications/Workflow/Step/Event_Content/Filter/Term.php
@@ -59,30 +59,30 @@ class Term extends Base implements Filter_Interface
     {
         $get_terms_to_exclude = [];
 
-        if ( class_exists( '\PP_Notifications' ) ) {
-            $blacklisted_taxonomies = \PP_Notifications::getOption( 'blacklisted_taxonomies' );
+        if (class_exists('\PP_Notifications')) {
+            $blacklisted_taxonomies = \PP_Notifications::getOption('blacklisted_taxonomies');
             if ( ! empty( $blacklisted_taxonomies ) ) {
-                $get_terms_to_exclude = array_filter( explode( ',', $blacklisted_taxonomies ) );
+                $get_terms_to_exclude = array_filter(explode(',', $blacklisted_taxonomies));
             }
         }
 
-        $terms = get_terms( [
+        $terms = get_terms([
             'hide_empty' => false,
-            'taxonomy'   => array_except( get_taxonomies(), $get_terms_to_exclude ),
-        ] );
+            'taxonomy'   => array_keys(array_except(get_taxonomies(), $get_terms_to_exclude),
+        ]);
 
-        $metadata = (array) $this->get_metadata( static::META_KEY_TERM );
+        $metadata = (array) $this->get_metadata(static::META_KEY_TERM);
 
         $options = [];
-        foreach ( $terms as $term ) {
+        foreach ($terms as $term) {
             $options[] = [
                 'value'    => $term->term_id,
                 'label'    => $term->taxonomy . '/' . $term->name,
-                'selected' => in_array( $term->term_id, $metadata ),
+                'selected' => in_array($term->term_id, $metadata),
             ];
         }
 
-        usort( $options, [ $this, 'sort_options' ] );
+        usort($options, [$this, 'sort_options']);
 
         return $options;
     }

--- a/libraries/Notifications/Workflow/Step/Event_Content/Filter/Term.php
+++ b/libraries/Notifications/Workflow/Step/Event_Content/Filter/Term.php
@@ -57,42 +57,32 @@ class Term extends Base implements Filter_Interface
      */
     protected function get_options()
     {
-        $get_terms_to_exclude = '';
+        $get_terms_to_exclude = [];
 
-        if (class_exists('\PP_Notifications')) {
-            $blacklisted_taxonomies = \PP_Notifications::getOption('blacklisted_taxonomies');
-            if (!empty($blacklisted_taxonomies)) {
-                $blacklisted_taxonomies = array_filter(explode(',', $blacklisted_taxonomies));
-                if (count($blacklisted_taxonomies) > 0) {
-                    $get_terms_to_exclude = get_terms([
-                        'fields'   => 'ids',
-                        'taxonomy' => $blacklisted_taxonomies,
-                    ]);
-
-                    if (is_wp_error($get_terms_to_exclude)) {
-                        $get_terms_to_exclude = '';
-                    }
-                }
+        if ( class_exists( '\PP_Notifications' ) ) {
+            $blacklisted_taxonomies = \PP_Notifications::getOption( 'blacklisted_taxonomies' );
+            if ( ! empty( $blacklisted_taxonomies ) ) {
+                $get_terms_to_exclude = array_filter( explode( ',', $blacklisted_taxonomies ) );
             }
         }
 
-        $terms = get_terms([
+        $terms = get_terms( [
             'hide_empty' => false,
-            'exclude'    => $get_terms_to_exclude,
-        ]);
+            'taxonomy'   => array_except( get_taxonomies(), $get_terms_to_exclude ),
+        ] );
 
-        $metadata = (array)$this->get_metadata(static::META_KEY_TERM);
+        $metadata = (array) $this->get_metadata( static::META_KEY_TERM );
 
         $options = [];
-        foreach ($terms as $term) {
+        foreach ( $terms as $term ) {
             $options[] = [
                 'value'    => $term->term_id,
                 'label'    => $term->taxonomy . '/' . $term->name,
-                'selected' => in_array($term->term_id, $metadata),
+                'selected' => in_array( $term->term_id, $metadata ),
             ];
         }
 
-        usort($options, [$this, 'sort_options']);
+        usort( $options, [ $this, 'sort_options' ] );
 
         return $options;
     }


### PR DESCRIPTION
Currently the following code is used to retrieve the term id's to exclude when retrieving all the terms:

```php
$get_terms_to_exclude = get_terms([
    'fields'   => 'ids',
    'taxonomy' => $blacklisted_taxonomies,
]);
```

The problem is that this code still retrieves _all_ excluded term id's which can be quite a large number.

The `get_terms` supports getting terms based on the taxonomy but does not allow to exclude them so we retrieve the taxonomies first and exclude the ones we don't want ourselfs and pass the list of allowed taxonomies to the `get_terms` to only retrieve the taxonomies we want.

This should fix #375.