### PR TITLE
Notifications bug fix, short code feature

### DIFF
--- a/includes.php
+++ b/includes.php
@@ -40,7 +40,7 @@ if ( ! defined('PP_LOADED')) {
     );
 
     // Define contants
-    define('PUBLISHPRESS_VERSION', '1.20.7');
+    define('PUBLISHPRESS_VERSION', '1.20.8-dev');
     define('PUBLISHPRESS_BASE_PATH', __DIR__);
     define('PUBLISHPRESS_FILE_PATH', PUBLISHPRESS_BASE_PATH . '/publishpress.php');
     define('PUBLISHPRESS_URL', plugins_url('/', __FILE__));

--- a/libraries/Notifications/Shortcodes.php
+++ b/libraries/Notifications/Shortcodes.php
@@ -413,6 +413,10 @@ class Shortcodes
                     break;
 
                 default:
+                    if ($custom = apply_filters('publishpress_notif_shortcode_post_data', false, $item, $post, $attrs)) {
+                        $info[] = $custom;
+                    }
+
                     break;
             }
         }

--- a/libraries/Notifications/Workflow/Workflow.php
+++ b/libraries/Notifications/Workflow/Workflow.php
@@ -260,7 +260,20 @@ class Workflow
      */
     public function get_related_posts($args = [])
     {
-        $post_status = (!empty($args['post_status'])) ? $args['post_status'] : 'future';
+        $workflow_meta_key = (!empty($args['meta_key_selected'])) ? $args['meta_key_selected'] : '_psppno_evtbeforepublishing';
+        
+        // We need to set a distinct "notification sent" flag for each workflow and notification criteria
+        if ('_psppno_evtbeforepublishing' == $workflow_meta_key) {
+            $post_status = (!empty($args['post_status'])) ? $args['post_status'] : 'future';
+
+            $notification_suffix = "_{$post_status}_{$this->workflow_post->ID}";
+
+        } elseif (!empty($args['post_status'])) {
+            $notification_suffix = "-{$workflow_meta_key}_" . $args['post_status'] . "_{$this->workflow_post->ID}";
+        } else {
+            // Other notification criteria may not specify a post status
+            $notification_suffix ="-{$workflow_meta_key}_{$this->workflow_post->ID}";
+        }
 
         $posts = [];
 
@@ -272,7 +285,7 @@ class Workflow
             'cache_results' => true,
             'meta_query'    => [
                 [
-                    'key'     => static::NOTIFICATION_SCHEDULE_META_KEY,
+                    'key'     => static::NOTIFICATION_SCHEDULE_META_KEY . $notification_suffix,
                     'compare' => 'NOT EXISTS',
                 ],
             ],

--- a/modules/async-notifications/library/Queue/WPCron.php
+++ b/modules/async-notifications/library/Queue/WPCron.php
@@ -91,7 +91,7 @@ class WPCron implements QueueInterface
             }
 
             do_action('publishpress_enqueue_notification', $workflowPost->ID, $actionArgs['action'],
-                $actionArgs['post']->ID);
+                $actionArgs['post']->ID, $actionArgs);
         }
     }
 

--- a/modules/improved-notifications/improved-notifications.php
+++ b/modules/improved-notifications/improved-notifications.php
@@ -725,6 +725,7 @@ if ( ! class_exists('PP_Improved_Notifications')) {
                     'format_text'      => __('On each shortcode, you can select one or more fields. If more than one, they will be displayed separated by ", ".',
                         'publishpress'),
                     'available_fields' => __('Available fields', 'publishpress'),
+                    'meta_fields' => __('Meta fields', 'publishpress'),
                     'read_more'        => __('Click here to read more about shortcode options...', 'publishpress'),
                 ],
             ];

--- a/publishpress.php
+++ b/publishpress.php
@@ -5,7 +5,7 @@
  * Description: The essential plugin for any WordPress site with multiple writers
  * Author: PublishPress
  * Author URI: https://publishpress.com
- * Version: 1.20.7
+ * Version: 1.20.8-dev
  *
  * Copyright (c) 2019 PublishPress
  *

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,10 @@ Not at all. You can set up everything your team needs without any coding knowled
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+= 1.20.8 =
+* Feature : Support post meta fields in notification body (also requires PublishPress Reminders 1.1.1)
+* Fixed : If Async Notifications enabled and more than one workflow notification applies to a post, the additional notifications were not sent (corresponding fix in PublishPress Reminders 1.1.1) 
+
 = [1.20.7] - 2019-06-17 =
 
 * Fix fatal error in wp-admin when active alongside WPML or another plugin that uses an obsolete version of the Twig library

--- a/twig/workflow_help.twig
+++ b/twig/workflow_help.twig
@@ -5,6 +5,7 @@
 <h4>{{ labels.content }}</h4>
 <pre>[psppno_post]</pre>
 <p>{{ labels.available_fields }}: <em>id, title, permalink, date, time, old_status, new_status, edit_link, author_display_name, author_email, author_login</em></p>
+<p>{{ labels.meta_fields }}: <em>meta meta_key, <br />meta-date meta_key</em></p>
 
 <h4>{{ labels.actor }}</h4>
 <pre>[psppno_actor]</pre>


### PR DESCRIPTION
This commit has a matching set in the similarly named branch of the PublishPress-Reminders project.

## Description
When multiple notifications applied to a post, only the first notification was sent.  This was due to sharing of the postmeta flag _psppre_notification_scheduled among all notifications.  The meta key is now suffixed with status and workflow post ID.  An additional suffix is applied for notification types other than "Before Publication."

This change set also adds support for [psppno_post meta meta_key] and [psppno_post meta-date meta_key].

## Benefits
Ability to send multiple pre-publication notifications for the same post with Async Notifications enabled.  Support insertion of postmeta scalars into notification message.

## Possible drawbacks
This will cause a one-time occurance of redundant pre-publish notifications, but only for posts with a publish date still in the future.

New twig caption "Meta fields" for help frame is not yet translated.

## Notes
\PublishPress\Notifications\Workflow\get_related_posts() is currently only called for "Before Publication" notifications

## Applicable issues
Known issue not logged in github?

## Checklist
- [x ] I have created an specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x ] I'm submitting to the `development`, topic/feature/bugfix branch. (Do not submit to the master branch!)
- [x ] This pull request is related to an specific problem (bug or improvement).
- [x ] All the issues mentioned in this pull request are related to the problem I'm trying to solve.
