### PR TITLE
Notifications metadata shortcode: fix onscreen help

### DIFF
--- a/twig/workflow_help.twig
+++ b/twig/workflow_help.twig
@@ -5,7 +5,7 @@
 <h4>{{ labels.content }}</h4>
 <pre>[psppno_post]</pre>
 <p>{{ labels.available_fields }}: <em>id, title, permalink, date, time, old_status, new_status, edit_link, author_display_name, author_email, author_login</em></p>
-<p>{{ labels.meta_fields }}: <em>meta meta_key, <br />meta-date meta_key</em></p>
+<p>{{ labels.meta_fields }}: <em>meta:meta_key, <br />meta-date:meta_key</em></p>
 
 <h4>{{ labels.actor }}</h4>
 <pre>[psppno_actor]</pre>


### PR DESCRIPTION
## Description
The twig file for onscreen help on the Edit Notification Workflow screen had the wrong syntax for specifying metadata in the [psppno_post] shortcode.

## Benefits
Correct onscreen shortcode example. Give our users a fighting chance to successfully retrieve post metadata.

## Possible drawbacks
none

## Applicable issues
https://github.com/publishpress/PublishPress/issues/479

## Checklist
- [x ] I have created an specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x ] I'm submitting to the `development`, topic/feature/bugfix branch. (Do not submit to the master branch!)
- [x ] This pull request is related to an specific problem (bug or improvement).
- [x ] All the issues mentioned in this pull request are related to the problem I'm trying to solve.
