### PR TITLE
Editorial Comment data is not filterable

### DIFF
--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -442,7 +442,7 @@ if (!class_exists('PP_Editorial_Comments')) {
                     'comment_approved'     => self::comment_type,
                 ];
 
-                apply_filters('pp_pre_insert_editorial_comment', $data);
+                $data = apply_filters('pp_pre_insert_editorial_comment', $data);
 
                 // Insert Comment
                 $comment_id = wp_insert_comment($data);

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,10 @@ Follow PublishPress on [Facebook](https://www.facebook.com/publishpress), [Twitt
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+= UNRELEASED =
+
+* Fixed: Fix PHP warning "Creating default object from empty value in publishpress-authors.php:772", correctly assigning the filter "pp_pre_insert_editorial_comment". (Allows PublishPress Revisions integration), #231;
+
 = [3.1.0] - 2021-01-20 =
 
 * Added: Add shortcodes to the email notifications for the post content, excerpt and post type, #288


### PR DESCRIPTION
Fixes #231

## Description
Correct assignment of filter 'pp_pre_insert_editorial_comment' return value

## Benefits
Allows for PublishPress Revisions integration

## Possible drawbacks
If another plugin already hooks into 'pp_pre_insert_editorial_comment' without returning a value correctly, this change will expose their error.

## Applicable issues
https://github.com/publishpress/PublishPress/issues/780

## Checklist

- [ X] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [X ] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [X ] This pull request relates to a specific problem (bug or improvement).
- [X ] I have mentioned the issue number in the pull request description text.
- [X ] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [X ] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
