### PR TITLE
Multisite: Role selection is ignored by Add User

### DIFF
--- a/modules/roles/roles.php
+++ b/modules/roles/roles.php
@@ -172,7 +172,12 @@ if (!class_exists('PP_Roles')) {
             add_action('publishpress_admin_submenu', [$this, 'action_admin_submenu'], 40);
 
             add_action('profile_update', [$this, 'action_profile_update'], 10, 2);
-            add_action('user_register', [$this, 'action_profile_update'], 9);
+
+            if (is_multisite()) {
+                add_action('add_user_to_blog', [$this, 'action_profile_update'], 9);
+            } else {
+            	add_action('user_register', [$this, 'action_profile_update'], 9);
+            }
 
             if ($this->wasPublishPressInstalledBefore()) {
                 add_action('publishpress_migrate_groups_to_role', [$this, 'migrateUserGroupsToRoles']);


### PR DESCRIPTION
## Description
Hook the existing action_profile_update() function to add_user_to_blog action when running on multisite.

## Benefits
Prevent the chosen.js role selection from being ignored when a user is added.

## Possible drawbacks
This is a partial fix. The new user is added correctly, but redirect back to the Add User page defaults the role selection to last selected role plus default role.

## Applicable issues
https://github.com/publishpress/PublishPress/issues/788

## Checklist

- [X] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [X] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [X] This pull request relates to a specific problem (bug or improvement).
- [X] I have mentioned the issue number in the pull request description text.
- [X] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [X] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
