### PR TITLE
Links to posts with custom privacy are changed to preview links

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -62,6 +62,12 @@ if (!class_exists('PP_Module')) {
                     $this->twig->addExtension(new Twig_Extension_Debug());
                 }
             }
+
+            foreach(get_post_stati(['public' => true, 'private' => true], 'names', 'OR') as $status) {
+                if (!in_array($status, $this->published_statuses)) {
+                    $this->published_statuses []= $status;
+                }
+            }
         }
 
         /**

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -2215,9 +2215,11 @@ if (!class_exists('PP_Custom_Status')) {
             }
 
             //Is this published?
-            if (in_array($post->post_status, $this->published_statuses)) {
-                return $permalink;
-            }
+            if ($status_obj = get_post_status_object($post->post_status)) {
+                if (!empty($status_obj->public) || !empty($status_obj->private)) {
+                	return $permalink;
+            	}
+            } 
 
             //Are we overriding the permalink? Don't do anything
             if (isset($_POST['action']) && $_POST['action'] == 'sample-permalink') {


### PR DESCRIPTION
Fixes #852

## Description
Account for custom privacy statuses when filtering menu links.

## Applicable issues
https://github.com/publishpress/PublishPress/issues/852

## Checklist

- [X] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [X] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [X] This pull request relates to a specific problem (bug or improvement).
- [X] I have mentioned the issue number in the pull request description text.
- [X] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [X] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
