### PR TITLE
feature/#1134_No_Save_Button_on_Editorial_Comment_Setting

### DIFF
--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -853,8 +853,28 @@ if (! class_exists('PP_Editorial_Comments')) {
          */
         public function print_configure_view()
         {
-            settings_fields($this->module->options_group_name);
-            do_settings_sections($this->module->options_group_name);
+            global $publishpress; ?>
+            <form class="basic-settings"
+                  action="<?php
+                  echo esc_url(menu_page_url($this->module->settings_slug, false)); ?>" method="post">
+                <?php
+                settings_fields($this->module->options_group_name); ?>
+                <?php
+                do_settings_sections($this->module->options_group_name); ?>
+                <?php
+                echo '<input id="publishpress_module_name" name="publishpress_module_name[]" type="hidden" value="' . esc_attr(
+                        $this->module->name
+                    ) . '" />'; ?>
+                <p class="submit"><?php
+                    submit_button(null, 'primary', 'submit', false); ?></p>
+                <?php
+                echo '<input name="publishpress_module_name[]" type="hidden" value="' . esc_attr(
+                        $this->module->name
+                    ) . '" />'; ?>
+                <?php
+                wp_nonce_field('edit-publishpress-settings'); ?>
+            </form>
+            <?php
         }
 
         /**


### PR DESCRIPTION
<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress plugin. Use your best judgment, and feel free to propose changes to this document in a pull request. 
  
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
  
  Please, review the guidelines for contributing to this repository:
  
  https://github.com/publishpress/PublishPress/blob/development/CONTRIBUTING.md
 -->

## Description
<!-- We must be able to understand the design of your change from this description. -->
- No Save Button on Editorial Comment Setting #1134

## Benefits
<!-- What benefits will be realized the code changes? -->

## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

## Applicable issues
<!-- Link any applicable Issues here -->
https://github.com/publishpress/PublishPress/issues/1134

## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
